### PR TITLE
Add YAML configuration loader

### DIFF
--- a/cfg_loader.py
+++ b/cfg_loader.py
@@ -1,0 +1,24 @@
+import os
+import yaml
+
+
+def load_yaml(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def load_config(medium: str, side: str):
+    base_dir = os.path.join(os.path.dirname(__file__), 'config')
+    config = {}
+    common_path = os.path.join(base_dir, 'common.yaml')
+    if os.path.exists(common_path):
+        config.update(load_yaml(common_path) or {})
+
+    medium_file = os.path.join(base_dir, f'{medium}.yaml')
+    if os.path.exists(medium_file):
+        medium_cfg = load_yaml(medium_file) or {}
+        specific_cfg = medium_cfg.get(side, {})
+        config.update(specific_cfg)
+    else:
+        raise FileNotFoundError(f'配置文件不存在: {medium_file}')
+    return config

--- a/config/MM.yaml
+++ b/config/MM.yaml
@@ -1,0 +1,10 @@
+front:
+  model_path: "models/MM_front_detector.pth"
+  min_colony_area: 45
+  color_enhance: true
+  use_unet_fallback: true
+back:
+  model_path: "models/MM_back_detector.pth"
+  min_colony_area: 30
+  color_enhance: false
+  use_unet_fallback: true

--- a/config/R5.yaml
+++ b/config/R5.yaml
@@ -1,0 +1,10 @@
+front:
+  model_path: "models/R5_front_detector.pth"
+  min_colony_area: 50
+  color_enhance: true
+  use_unet_fallback: false
+back:
+  model_path: "models/R5_back_detector.pth"
+  min_colony_area: 30
+  color_enhance: false
+  use_unet_fallback: true

--- a/config/common.yaml
+++ b/config/common.yaml
@@ -1,0 +1,3 @@
+unet_model_path: "models/unet_segmenter.pth"
+fallback_min_colonies: 5
+output_dir: "results/"


### PR DESCRIPTION
## Summary
- implement `cfg_loader.py` to load YAML configs
- add example YAMLs for R5 and MM media plus global common config
- pass medium/side params in `main.py` and integrate loaded config
- allow pipeline to consume config dict and control fallback behaviour

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849bd1a1d388332a7054b912a240c8c