### PR TITLE
Add evaluation pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,7 @@ results/
 - 通用工具如 `collect_all_images` 和 `parse_filename` 位于 `colony_analysis/utils/file_utils.py`。
 - 批量调度逻辑在 `colony_analysis/pipeline.py` 的 `batch_medium_pipeline` 函数中。
 
+### 更多文档
+- 轻量级分割与评估管线请参见 [docs/segmentation_pipeline.md](docs/segmentation_pipeline.md)
+
 欢迎提交 Issue 和 Pull Request!

--- a/colony_analysis/__init__.py
+++ b/colony_analysis/__init__.py
@@ -13,11 +13,36 @@ Colony Analysis Package 2.0
 __version__ = "2.0.0"
 __author__ = "Colony Analysis Team"
 
-from .analysis import ColonyAnalyzer, FeatureExtractor, ScoringSystem
-# 导入主要类
-from .config import ConfigManager
-from .core import ColonyDetector, SAMModel
-from .utils import LogManager, ResultManager, Visualizer
+# 延迟导入主要模块，避免在导入包时触发繁重依赖
+def __getattr__(name):
+    if name == "ColonyAnalyzer":
+        from .analysis import ColonyAnalyzer
+        return ColonyAnalyzer
+    if name == "FeatureExtractor":
+        from .analysis import FeatureExtractor
+        return FeatureExtractor
+    if name == "ScoringSystem":
+        from .analysis import ScoringSystem
+        return ScoringSystem
+    if name == "ConfigManager":
+        from .config import ConfigManager
+        return ConfigManager
+    if name == "SAMModel":
+        from .core import SAMModel
+        return SAMModel
+    if name == "ColonyDetector":
+        from .core import ColonyDetector
+        return ColonyDetector
+    if name == "LogManager":
+        from .utils import LogManager
+        return LogManager
+    if name == "ResultManager":
+        from .utils import ResultManager
+        return ResultManager
+    if name == "Visualizer":
+        from .utils import Visualizer
+        return Visualizer
+    raise AttributeError(name)
 
 __all__ = [
     "ConfigManager",

--- a/colony_analysis/evaluator.py
+++ b/colony_analysis/evaluator.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import cv2
+import numpy as np
+import yaml
+
+from .config.config_loader import parse_condition_from_path
+from .segmenters.sam_segmenter import SamSegmenter
+from .segmenters.unet_segmenter import UnetSegmenter
+
+try:
+    from colony_analysis.segmenters.fastsam_segmenter import FastSamSegmenter
+except Exception:  # pragma: no cover - optional dependency
+    FastSamSegmenter = None
+
+try:
+    from colony_analysis.segmenters.segformer_segmenter import SegFormerSegmenter
+except Exception:  # pragma: no cover - optional dependency
+    SegFormerSegmenter = None
+
+
+def load_model(cfg: Dict[str, Any]):
+    name = (cfg.get("name") or cfg.get("model"))
+    if not name:
+        raise ValueError("Model name missing in config")
+    name = name.lower()
+    weights = cfg.get("weights")
+    if name == "sam":
+        return SamSegmenter(model_path=weights, model_type=cfg.get("variant", "vit_b"))
+    if name == "unet":
+        threshold = float(cfg.get("threshold", 0.5))
+        return UnetSegmenter(model_path=weights, threshold=threshold)
+    if name == "fastsam":
+        if FastSamSegmenter is None:
+            raise ImportError("FastSamSegmenter not available")
+        return FastSamSegmenter(model_path=weights)
+    if name == "segformer":
+        if SegFormerSegmenter is None:
+            raise ImportError("SegFormerSegmenter not available")
+        threshold = float(cfg.get("threshold", 0.5))
+        return SegFormerSegmenter(weights=weights, threshold=threshold)
+    raise ValueError(f"Unsupported model: {name}")
+
+
+def compute_metrics(pred_masks: List[np.ndarray], true_masks: List[np.ndarray]) -> Dict[str, float]:
+    tp = min(len(pred_masks), len(true_masks))
+    fp = max(0, len(pred_masks) - len(true_masks))
+    fn = max(0, len(true_masks) - len(pred_masks))
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "false_positive": fp,
+        "false_negative": fn,
+    }
+
+
+def evaluate_colonies(image_path: str, config_path: str) -> Dict[str, Any]:
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+
+    medium, side = parse_condition_from_path(image_path)
+    key = f"{medium}_{side}"
+    default_cfg = (config.get("defaults", {}) or {}).get(key)
+
+    experiment_cfgs: List[Dict[str, Any]] = []
+    for exp in config.get("experiments", []):
+        if exp.get("medium") == medium and exp.get("side") == side:
+            models = exp.get("models", [])
+            for m in models:
+                if isinstance(m.get("threshold"), list):
+                    for t in m["threshold"]:
+                        mc = m.copy()
+                        mc["threshold"] = t
+                        experiment_cfgs.append(mc)
+                else:
+                    experiment_cfgs.append(m)
+
+    if not experiment_cfgs and default_cfg:
+        experiment_cfgs.append(default_cfg)
+
+    image = cv2.imread(image_path)
+    if image is None:
+        raise FileNotFoundError(image_path)
+
+    gt_masks: List[np.ndarray] = []
+    base = Path(image_path).stem
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+
+    results = []
+    for cfg in experiment_cfgs:
+        try:
+            model = load_model(cfg)
+            pred = model.segment(image)
+            if isinstance(pred, np.ndarray):
+                pred_masks = [pred]
+            else:
+                pred_masks = pred
+            metrics = compute_metrics(pred_masks, gt_masks)
+        except Exception as e:  # pragma: no cover - runtime safety
+            metrics = {"error": str(e)}
+        result = {**cfg, **metrics}
+        results.append(result)
+        with open(log_dir / f"{base}_{cfg.get('name','model')}.json", "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+
+    best = max((r for r in results if "f1" in r), key=lambda x: x.get("f1", 0.0), default=None)
+    return {"best_model": best.get("name") if best else None, "metrics": results}

--- a/colony_analysis/segmenters/__init__.py
+++ b/colony_analysis/segmenters/__init__.py
@@ -2,5 +2,12 @@
 
 from .sam_segmenter import SamSegmenter
 from .unet_segmenter import UnetSegmenter
+from .fastsam_segmenter import FastSamSegmenter
+from .segformer_segmenter import SegFormerSegmenter
 
-__all__ = ["SamSegmenter", "UnetSegmenter"]
+__all__ = [
+    "SamSegmenter",
+    "UnetSegmenter",
+    "FastSamSegmenter",
+    "SegFormerSegmenter",
+]

--- a/colony_analysis/segmenters/fastsam_segmenter.py
+++ b/colony_analysis/segmenters/fastsam_segmenter.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import List, Optional
+import numpy as np
+
+try:
+    from ultralytics import FastSAM
+except Exception:  # pragma: no cover - optional dependency
+    FastSAM = None
+
+
+class FastSamSegmenter:
+    """Lightweight wrapper for FastSAM segmentation."""
+
+    def __init__(self, model_path: str, device: Optional[str] = None) -> None:
+        if FastSAM is None:
+            raise ImportError("ultralytics package is required for FastSAM")
+        self.model = FastSAM(model_path)
+        self.device = device
+
+    def segment(self, image: np.ndarray) -> List[np.ndarray]:
+        """Return list of masks predicted by FastSAM."""
+        results = self.model.predict(source=image, device=self.device or "cpu")
+        masks = getattr(results, "masks", None)
+        if masks is None:
+            return []
+        return [m for m in masks.data]

--- a/colony_analysis/segmenters/sam_segmenter.py
+++ b/colony_analysis/segmenters/sam_segmenter.py
@@ -2,7 +2,10 @@ import os
 from typing import Tuple, List
 import numpy as np
 
-from ..core.sam_model import SAMModel
+try:
+    from ..core.sam_model import SAMModel
+except Exception:  # pragma: no cover - optional dependency
+    SAMModel = None
 
 
 class SamSegmenter:
@@ -10,6 +13,8 @@ class SamSegmenter:
     pipeline."""
 
     def __init__(self, model_path: str = None, model_type: str = "vit_b") -> None:
+        if SAMModel is None:
+            raise ImportError("SAMModel is required for SamSegmenter")
         # ``SAMModel`` resolves a default checkpoint path if ``model_path`` is None
         self.model = SAMModel(model_type=model_type, checkpoint_path=model_path)
         # Expose the underlying mask generator for direct use

--- a/colony_analysis/segmenters/segformer_segmenter.py
+++ b/colony_analysis/segmenters/segformer_segmenter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+import numpy as np
+
+try:
+    import torch
+    from transformers import (
+        SegformerFeatureExtractor,
+        SegformerForSemanticSegmentation,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+    SegformerFeatureExtractor = None
+    SegformerForSemanticSegmentation = None
+
+
+class SegFormerSegmenter:
+    """Simplified SegFormer-based segmenter."""
+
+    def __init__(self, weights: str, threshold: float = 0.5, device: Optional[str] = None) -> None:
+        if torch is None or SegformerFeatureExtractor is None:
+            raise ImportError("transformers package with SegFormer is required")
+        self.feature_extractor = SegformerFeatureExtractor.from_pretrained(weights)
+        self.model = SegformerForSemanticSegmentation.from_pretrained(weights)
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model.to(self.device)
+        self.threshold = threshold
+
+    def segment(self, image: np.ndarray) -> np.ndarray:
+        inputs = self.feature_extractor(images=image, return_tensors="pt")
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+        mask = outputs.logits.softmax(dim=1)[0, 1]
+        mask_np = mask.cpu().numpy()
+        return (mask_np > self.threshold).astype(np.uint8)

--- a/colony_analysis/segmenters/unet_segmenter.py
+++ b/colony_analysis/segmenters/unet_segmenter.py
@@ -2,15 +2,23 @@ import os
 from typing import Optional
 
 import numpy as np
-import torch
-import torch.nn.functional as F
-import segmentation_models_pytorch as smp
+
+try:
+    import torch
+    import torch.nn.functional as F
+    import segmentation_models_pytorch as smp
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+    F = None
+    smp = None
 
 
 class UnetSegmenter:
     """Simple U-Net based segmenter used as a fallback when SAM masks fail."""
 
     def __init__(self, model_path: str, device: Optional[str] = None, threshold: float = 0.5) -> None:
+        if torch is None or smp is None:
+            raise ImportError("PyTorch and segmentation_models_pytorch are required for UnetSegmenter")
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
         self.threshold = threshold
         self.model = smp.Unet(

--- a/docs/segmentation_pipeline.md
+++ b/docs/segmentation_pipeline.md
@@ -1,0 +1,47 @@
+# Colony Segmentation and Evaluation Pipeline
+
+此文档概述了在项目中引入轻量级菌落分割模型以及评估流程的设计思路。内容包括模型选择、与现有系統的集成方式、自动化评估、配置化管理以及核心函数接口示例。
+
+## 1. 模型选择
+
+在 GPU 资源有限的情况下，可选的轻量模型包括：
+
+- **U-Net**：经典卷积下采样/上采样结构，可在 Segmentation Models PyTorch(SMP) 中加载预训练编码器并快速微调。
+- **FastSAM**：基于 YOLOv8 分割头的 Segment Anything 轻量实现，无需提示即可分割图像中所有对象，可作为兜底方案。
+- **SegFormer**：NVIDIA 提出的高效 Transformer 架构，B0/B1 等小型号仅数百万参数，适合在不同培养基和成像条件下保持鲁棒。
+
+## 2. 与现有系统集成
+
+将不同分割模型封装为统一接口 `segment(image) -> masks`，然后在 SAM3.0 的 `fallback` 或 `ensemble` 流程中按需调用。可先运行主模型，若判断为漏检则调用兜底模型补充；或多模型并行推理后合并结果。
+
+## 3. 评估流程
+
+评估管线读取图像路径以及培养基和拍摄方向，根据配置加载对应模型运行分割，并与弱标注真值比对。指标包括 Precision、Recall、F1、IoU 等。每次评估都会输出日志（JSON）并在 CSV 表中汇总，便于比较不同模型和参数组合的效果。
+
+```python
+# 示例入口接口
+from pipeline import evaluate_colonies
+summary = evaluate_colonies("images/sample_MMM_front.jpg", "config.yaml")
+```
+
+## 4. 配置化管理
+
+配置文件采用 YAML 格式，为不同培养基与拍摄方向指定默认模型及参数，同时允许在 `experiments` 中列出额外的模型组合进行对比。更改配置即可添加新模型或调整阈值，无需修改代码。
+
+```yaml
+# config.yaml 中的示例片段
+defaults:
+  "R5_front":
+    model: "FastSAM"
+    weights: "./weights/FastSAM.pt"
+    threshold: 0.5
+```
+
+## 5. 模块与接口
+
+- `config.py`：加载与解析 YAML 配置。
+- `models/`：实现 `BaseModel` 及 `FastSAMModel`、`UNetModel`、`SegFormerModel` 等子类。
+- `metrics.py`：提供掩膜匹配与指标计算函数。
+- `pipeline.py`：实现 `evaluate_colonies`，串联读取配置、模型推理、评估和日志输出。
+
+通过模块化设计，后续可轻松扩展新的分割模型或指标，并利用 Codex 自动生成剩余实现。


### PR DESCRIPTION
## Summary
- outline evaluation pipeline with `evaluate_colonies` helper
- provide FastSAM and SegFormer segmenter stubs
- export the new segmenters in the package initializer
- link the segmentation pipeline document from the README
- fix imports so evaluator loads even without heavy dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d244d86883328b4e849f67cc4c1f