### PR TITLE
Fix CPU model loading

### DIFF
--- a/colony_analysis/core/sam_model.py
+++ b/colony_analysis/core/sam_model.py
@@ -46,9 +46,10 @@ class SAMModel:
             self.sam = ModelClass()
         # 手动加载 checkpoint，根据 device 强制映射到 CPU 或 GPU
         if self.device.type == "cpu":
-            state = torch.load(self.checkpoint_path, map_location="cpu")
+            map_loc = lambda storage, loc: storage.cpu()
         else:
-            state = torch.load(self.checkpoint_path, map_location=self.device)
+            map_loc = self.device
+        state = torch.load(self.checkpoint_path, map_location=map_loc)
         if isinstance(state, dict) and 'model_state_dict' in state:
             state = state['model_state_dict']
         self.sam.load_state_dict(state, strict=False)

--- a/colony_analysis/segmenters/unet_segmenter.py
+++ b/colony_analysis/segmenters/unet_segmenter.py
@@ -29,7 +29,12 @@ class UnetSegmenter:
         )
         if not os.path.exists(model_path):
             raise FileNotFoundError(f"Unet model weights not found: {model_path}")
-        state_dict = torch.load(model_path, map_location=self.device)
+        map_loc = (
+            (lambda storage, loc: storage.cpu())
+            if self.device.type == "cpu"
+            else self.device
+        )
+        state_dict = torch.load(model_path, map_location=map_loc)
         self.model.load_state_dict(state_dict, strict=False)
         self.model.to(self.device)
         self.model.eval()


### PR DESCRIPTION
## Summary
- avoid GPU-only map location when loading SAM weights
- handle CPU-only loading for U-Net fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ee9b71848332b5119e72879c3e7c