### PR TITLE
Improve interactive HTML reports

### DIFF
--- a/report_templates/assets/style.css
+++ b/report_templates/assets/style.css
@@ -3,3 +3,18 @@ h1 { margin-top: 0; }
 .colony-img { max-width: 45%; margin-right: 1%; }
 table { border-collapse: collapse; width: 100%; margin-top: 1em; }
 th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+
+.img-wrapper { position: relative; display: inline-block; }
+.img-wrapper img { display: block; width: 100%; height: auto; }
+.img-wrapper svg.overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+.mask-poly { fill: rgba(0,255,0,0.3); stroke: #0f0; stroke-width: 1; }
+#tooltip {
+  position: absolute;
+  display: none;
+  background: rgba(255,255,255,0.9);
+  border: 1px solid #666;
+  padding: 4px;
+  border-radius: 4px;
+  pointer-events: none;
+  font-size: 0.9em;
+}

--- a/report_templates/replicate.html.j2
+++ b/report_templates/replicate.html.j2
@@ -8,10 +8,19 @@
 </head>
 <body>
   <h1>{{ replicate.name }}</h1>
-  <div>
-    {% if replicate.front_img %}<img src="{{ replicate.front_img }}" class="colony-img">{% endif %}
-    {% if replicate.back_img %}<img src="{{ replicate.back_img }}" class="colony-img">{% endif %}
+  <label><input type="checkbox" id="maskToggle"> 显示掩膜</label>
+  {% if replicate.front_img %}
+  <div class="img-wrapper">
+    <img id="frontImg" src="{{ replicate.front_img }}" class="colony-img">
+    <svg id="maskLayer" class="overlay"></svg>
   </div>
+  {% endif %}
+  {% if replicate.back_img %}
+  <div class="img-wrapper">
+    <img id="backImg" src="{{ replicate.back_img }}" class="colony-img">
+  </div>
+  {% endif %}
+  <div id="tooltip" class="tooltip"></div>
   <h2>Colonies</h2>
   <table>
     <thead><tr>{% for h in headers %}<th>{{ h }}</th>{% endfor %}</tr></thead>
@@ -31,6 +40,51 @@
       data: {labels: labels, datasets: [{label: 'Area', data: data}]},
       options: {scales: {x: {title:{display:true,text:'Colony'}}, y:{title:{display:true,text:'Area'}}}}
     });
+
+    const colonies = {{ colonies_json|safe }};
+    const polygons = {{ polygons_json|safe }};
+    const svg = document.getElementById('maskLayer');
+    const toggle = document.getElementById('maskToggle');
+    const tooltip = document.getElementById('tooltip');
+
+    function showTooltip(index, evt) {
+      const c = colonies[index] || {};
+      let html = '';
+      for (const k in c) {
+        if (typeof c[k] === 'object') {
+          html += `<div><strong>${k}</strong>: ${JSON.stringify(c[k])}</div>`;
+        } else {
+          html += `<div><strong>${k}</strong>: ${c[k]}</div>`;
+        }
+      }
+      tooltip.innerHTML = html;
+      tooltip.style.display = 'block';
+      tooltip.style.left = evt.pageX + 10 + 'px';
+      tooltip.style.top = evt.pageY + 10 + 'px';
+    }
+
+    function hideTooltip() {
+      tooltip.style.display = 'none';
+    }
+
+    function createPolygons() {
+      polygons.forEach((poly, idx) => {
+        if (!poly) return;
+        const p = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+        p.setAttribute('points', poly.map(pt => pt.join(',')).join(' '));
+        p.classList.add('mask-poly');
+        p.addEventListener('mousemove', evt => showTooltip(idx, evt));
+        p.addEventListener('mouseleave', hideTooltip);
+        svg.appendChild(p);
+      });
+    }
+
+    toggle.addEventListener('change', () => {
+      svg.style.display = toggle.checked ? 'block' : 'none';
+    });
+
+    createPolygons();
+    svg.style.display = 'none';
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend `integrate_report.py` to safely parse colony data and extract polygons
- generate polygon data and colony info for templates
- add overlay and tooltip interactions in `replicate.html.j2`
- tweak CSS for overlays and tooltips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c52ce2bd4833291f9b48664f007eb