### PR TITLE
Fix bbox orientation in overlay

### DIFF
--- a/colony_analysis/utils/visualization.py
+++ b/colony_analysis/utils/visualization.py
@@ -319,6 +319,14 @@ class Visualizer:
                 full_mask = np.zeros(img_rgb.shape[:2], dtype=mask.dtype)
                 if colony_data and i < len(colony_data) and 'bbox' in colony_data[i]:
                     minr, minc, maxr, maxc = colony_data[i]['bbox']
+                    # 自动修正潜在的 (x1, y1, x2, y2) 顺序错误
+                    if maxr <= minr or maxc <= minc:
+                        alt_minr, alt_minc, alt_maxr, alt_maxc = minc, minr, maxc, maxr
+                        if alt_maxr > alt_minr and alt_maxc > alt_minc:
+                            logging.warning(
+                                f"auto-fixing bbox order for colony {i}: {(minr, minc, maxr, maxc)}"
+                            )
+                            minr, minc, maxr, maxc = alt_minr, alt_minc, alt_maxr, alt_maxc
                     img_h, img_w = img_rgb.shape[:2]
                     h, w = mask.shape[:2]
                     exp_h, exp_w = maxr - minr, maxc - minc
@@ -560,6 +568,13 @@ class ImprovedVisualizer:
                 full_mask = np.zeros(img_rgb.shape[:2], dtype=mask.dtype)
                 if colony_data and i < len(colony_data) and 'bbox' in colony_data[i]:
                     minr, minc, maxr, maxc = colony_data[i]['bbox']
+                    if maxr <= minr or maxc <= minc:
+                        alt_minr, alt_minc, alt_maxr, alt_maxc = minc, minr, maxc, maxr
+                        if alt_maxr > alt_minr and alt_maxc > alt_minc:
+                            logging.warning(
+                                f"auto-fixing bbox order for colony {i}: {(minr, minc, maxr, maxc)}"
+                            )
+                            minr, minc, maxr, maxc = alt_minr, alt_minc, alt_maxr, alt_maxc
                     img_h, img_w = img_rgb.shape[:2]
                     h, w = mask.shape[:2]
                     exp_h, exp_w = maxr - minr, maxc - minc

--- a/tests/test_overlay_bbox_fix.py
+++ b/tests/test_overlay_bbox_fix.py
@@ -1,0 +1,16 @@
+import numpy as np
+from pathlib import Path
+from colony_analysis.utils.visualization import ImprovedVisualizer
+
+
+def test_overlay_bbox_autofix(tmp_path):
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    mask = np.ones((20, 20), dtype=bool)
+    colonies = [{"bbox": (10, 30, 30, 50), "mask": mask}]
+    viz = ImprovedVisualizer(str(tmp_path))
+    # Provide incorrectly ordered bbox (x1,y1,x2,y2)
+    colonies_bad = [{"bbox": (30, 10, 50, 30), "mask": mask}]
+    try:
+        viz.overlay_masks(img, [mask], Path(tmp_path), colonies_bad)
+    except Exception as e:
+        raise AssertionError(f"overlay_masks raised {e}")


### PR DESCRIPTION
## Summary
- handle swapped bbox order automatically in overlay masks
- add regression test for bbox order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a9d1f1bc8332b61aeb26fe97be6e